### PR TITLE
Treat limit resource as deleted if not found in Read

### DIFF
--- a/rabbitmq/resource_limit.go
+++ b/rabbitmq/resource_limit.go
@@ -138,7 +138,9 @@ func ReadLimit(d *schema.ResourceData, meta interface{}) error {
 		return nil
 	}
 
-	return fmt.Errorf("limit %s was not found", limit)
+	log.Printf("[WARN] limit %s was not found", limit)
+	d.SetId("")
+	return nil
 }
 
 func DeleteLimit(d *schema.ResourceData, meta interface{}) error {


### PR DESCRIPTION
L123-126 was improved in 33627a94944cd2bc9dc361265b2ceae3474c693e to mark the resource as deleted if the API responds with 404, however since this API endpoint returns an array it may return an empty array rather than a 404 if the user exists but the limits doesn't, and in this case the whole terraform run shouldn't be stopped (current behaviour) but rather the resource should be marked as deleted outside of terraform